### PR TITLE
Implement transports for ZeroMQ and Flume.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 * Arto Bendiken <arto@bendiken.net>
+* Joshua J. Bouw <hi@jjb.rs>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,2 @@
 * Arto Bendiken <arto@bendiken.net>
-* Joshua J. Bouw <hi@jjb.rs>
+* Joshua J. Bouw <dev@joshuajbouw.com>

--- a/lib/protoflow/src/transport.rs
+++ b/lib/protoflow/src/transport.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use prost::Message;
+use crate::Message;
 
 /// A trait for sending messages.
 pub trait Sender<M: Message> {

--- a/lib/protoflow/src/transport.rs
+++ b/lib/protoflow/src/transport.rs
@@ -1,1 +1,27 @@
 // This is free and unencumbered software released into the public domain.
+
+use prost::Message;
+
+/// A trait for sending messages.
+pub trait Sender<M: Message> {
+    /// Sends a message.
+    fn send(&mut self, message: M) -> Result<(), ()>;
+
+    /// Closes the sender.
+    fn close(&mut self) -> Result<(), ()>;
+
+    /// Returns whether the sender is closed.
+    fn is_closed(&self) -> bool;
+}
+
+/// A trait for receiving messages.
+pub trait Receiver<M: Message> {
+    /// Receives a message.
+    fn recv(&mut self) -> Result<M, ()>;
+
+    /// Closes the receiver.
+    fn close(&mut self) -> Result<(), ()>;
+
+    /// Returns whether the receiver is closed.
+    fn is_closed(&self) -> bool;
+}

--- a/lib/protoflow/src/transports/flume.rs
+++ b/lib/protoflow/src/transports/flume.rs
@@ -1,14 +1,18 @@
 // This is free and unencumbered software released into the public domain.
 
-use prost::Message;
-
+use crate::Message;
 use crate::transport::{Receiver, Sender};
 
+#[derive(Debug, Default)]
 pub struct FlumeSender<M> {
     sender: Option<flume::Sender<M>>,
 }
 
 impl<M: Message> FlumeSender<M> {
+    pub fn new() -> Self {
+        Self { sender: None }
+    }
+
     pub fn open(sender: flume::Sender<M>) -> Self {
         Self {
             sender: Some(sender),
@@ -44,8 +48,21 @@ impl<M: Message> Sender<M> for FlumeSender<M> {
     }
 }
 
+#[derive(Debug, Default)]
 pub struct FlumeReceiver<T> {
     receiver: Option<flume::Receiver<T>>,
+}
+
+impl<M: Message> FlumeReceiver<M> {
+    pub fn new() -> Self {
+        Self { receiver: None }
+    }
+
+    pub fn open(receiver: flume::Receiver<M>) -> Self {
+        Self {
+            receiver: Some(receiver),
+        }
+    }
 }
 
 impl<M: Message> Receiver<M> for FlumeReceiver<M> {

--- a/lib/protoflow/src/transports/zeromq.rs
+++ b/lib/protoflow/src/transports/zeromq.rs
@@ -1,17 +1,24 @@
+// This is free and unencumbered software released into the public domain.
+
 use futures::TryFutureExt;
-use prost::Message;
+#[cfg(feature = "tokio")]
 use tokio::{runtime::Handle, task};
 use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend};
 
-// This is free and unencumbered software released into the public domain.
+use crate::Message;
 use crate::transport::{Receiver, Sender};
 
+#[derive(Default)]
 pub struct ZmqSender {
     socket: Option<PushSocket>,
 }
 
 impl ZmqSender {
-    pub fn open(endpoint: &str) -> Result<Self, ()> {
+    pub fn new() -> Self {
+        Self { socket: None }
+    }
+
+    pub fn open(&mut self, endpoint: &str) -> Result<(), ()> {
         let mut socket = PushSocket::new();
         let socket = task::block_in_place(|| {
             Handle::current().block_on(async {
@@ -19,9 +26,8 @@ impl ZmqSender {
                 Ok(socket)
             })
         })?;
-        Ok(Self {
-            socket: Some(socket),
-        })
+        self.socket = Some(socket);
+        Ok(())
     }
 }
 
@@ -58,12 +64,17 @@ impl<M: Message> Sender<M> for ZmqSender {
     }
 }
 
+#[derive(Default)]
 pub struct ZmqReceiver {
     socket: Option<PullSocket>,
 }
 
 impl ZmqReceiver {
-    pub fn open(endpoint: &str) -> Result<Self, ()> {
+    pub fn new() -> Self {
+        Self { socket: None }
+    }
+
+    pub fn open(&mut self, endpoint: &str) -> Result<(), ()> {
         let mut socket = PullSocket::new();
         let socket = task::block_in_place(|| {
             Handle::current().block_on(async {
@@ -71,9 +82,8 @@ impl ZmqReceiver {
                 Ok(socket)
             })
         })?;
-        Ok(Self {
-            socket: Some(socket),
-        })
+        self.socket = Some(socket);
+        Ok(())
     }
 }
 

--- a/lib/protoflow/src/transports/zeromq.rs
+++ b/lib/protoflow/src/transports/zeromq.rs
@@ -1,3 +1,116 @@
-// This is free and unencumbered software released into the public domain.
+use futures::TryFutureExt;
+use prost::Message;
+use tokio::{runtime::Handle, task};
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend};
 
-pub struct ZeroMQ {}
+// This is free and unencumbered software released into the public domain.
+use crate::transport::{Receiver, Sender};
+
+pub struct ZmqSender {
+    socket: Option<PushSocket>,
+}
+
+impl ZmqSender {
+    pub fn open(endpoint: &str) -> Result<Self, ()> {
+        let mut socket = PushSocket::new();
+        let socket = task::block_in_place(|| {
+            Handle::current().block_on(async {
+                socket.connect(endpoint).map_err(|_| ()).await?;
+                Ok(socket)
+            })
+        })?;
+        Ok(Self {
+            socket: Some(socket),
+        })
+    }
+}
+
+impl<M: Message> Sender<M> for ZmqSender {
+    fn send(&mut self, message: M) -> Result<(), ()> {
+        task::block_in_place(move || {
+            Handle::current().block_on(async move {
+                if let Some(socket) = &mut self.socket {
+                    let bytes = message.encode_to_vec();
+                    socket.send(bytes.into()).await.map_err(|_| ())
+                } else {
+                    Err(())
+                }
+            })
+        })
+    }
+
+    fn close(&mut self) -> Result<(), ()> {
+        let socket = self.socket.take();
+        if let Some(socket) = socket {
+            task::block_in_place(move || {
+                Handle::current().block_on(async move {
+                    let _ = socket.close().await;
+                    Ok(())
+                })
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        self.socket.is_none()
+    }
+}
+
+pub struct ZmqReceiver {
+    socket: Option<PullSocket>,
+}
+
+impl ZmqReceiver {
+    pub fn open(endpoint: &str) -> Result<Self, ()> {
+        let mut socket = PullSocket::new();
+        let socket = task::block_in_place(|| {
+            Handle::current().block_on(async {
+                socket.bind(endpoint).map_err(|_| ()).await?;
+                Ok(socket)
+            })
+        })?;
+        Ok(Self {
+            socket: Some(socket),
+        })
+    }
+}
+
+impl<M: Message + Default> Receiver<M> for ZmqReceiver {
+    fn recv(&mut self) -> Result<M, ()> {
+        task::block_in_place(move || {
+            Handle::current().block_on(async move {
+                if let Some(socket) = &mut self.socket {
+                    socket
+                        .recv()
+                        .await
+                        .map_err(|_| ())?
+                        .get(0)
+                        .map(|b| M::decode(b.as_ref()).map_err(|_| ()))
+                        .ok_or(())?
+                } else {
+                    Err(())
+                }
+            })
+        })
+    }
+
+    fn close(&mut self) -> Result<(), ()> {
+        let socket = self.socket.take();
+        if let Some(socket) = socket {
+            task::block_in_place(move || {
+                Handle::current().block_on(async move {
+                    let _ = socket.close().await;
+                    Ok(())
+                })
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        self.socket.is_none()
+    }
+}


### PR DESCRIPTION
This adds the ZMQ and Flume transports. ZMQ is async by default, which made the implementation a little awkward, but having the transports all sync should be fine, and follows the trait spec. Async will be handled on another layer.