### PR TITLE
Refactor tracing dependencies

### DIFF
--- a/lib/protoflow-blocks/Cargo.toml
+++ b/lib/protoflow-blocks/Cargo.toml
@@ -24,13 +24,7 @@ hash-sha1 = ["dep:sha1"]
 hash-sha2 = ["dep:sha2"]
 
 rand = ["protoflow-core/rand"]
-std = [
-    "blake3?/std",
-    "protoflow-core/std",
-    "serde?/std",
-    "sysml-model?/std",
-    "tracing?/std",
-]
+std = ["blake3?/std", "protoflow-core/std", "serde?/std", "sysml-model?/std"]
 serde = [
     "duration-str/serde",
     "protoflow-core/serde",
@@ -40,7 +34,7 @@ serde = [
 ]
 sysml = ["protoflow-core/sysml", "dep:sysml-model"]
 tokio = ["protoflow-core/tokio", "dep:tokio"]
-tracing = ["protoflow-core/tracing", "dep:tracing"]
+tracing = ["protoflow-core/tracing"]
 unstable = ["protoflow-core/unstable", "protoflow-derive/unstable"]
 
 [build-dependencies]
@@ -54,7 +48,6 @@ md-5 = { version = "0.10.6", default-features = false, optional = true }
 protoflow-core.workspace = true
 protoflow-derive.workspace = true
 tokio = { version = "1.40.0", default-features = false, optional = true }
-tracing = { version = "0.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = [
     "derive",
 ], optional = true }

--- a/lib/protoflow-crossbeam/Cargo.toml
+++ b/lib/protoflow-crossbeam/Cargo.toml
@@ -17,8 +17,8 @@ publish.workspace = true
 [features]
 default = ["all", "std"]
 all = ["tracing"]
-std = ["crossbeam/std", "protoflow-core/std", "tracing?/std"]
-tracing = ["protoflow-core/tracing", "dep:tracing"]
+std = ["crossbeam/std", "protoflow-core/std"]
+tracing = ["protoflow-core/tracing"]
 unstable = ["protoflow-core/unstable"]
 
 [build-dependencies]
@@ -27,6 +27,5 @@ cfg_aliases.workspace = true
 [dependencies]
 crossbeam = { version = "0.8", default-features = false }
 protoflow-core.workspace = true
-tracing = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/lib/protoflow-flume/Cargo.toml
+++ b/lib/protoflow-flume/Cargo.toml
@@ -17,8 +17,8 @@ publish.workspace = true
 [features]
 default = ["all", "std"]
 all = ["tracing"]
-std = ["protoflow-core/std", "tracing?/std"]
-tracing = ["protoflow-core/tracing", "dep:tracing"]
+std = ["protoflow-core/std"]
+tracing = ["protoflow-core/tracing"]
 unstable = ["protoflow-core/unstable"]
 
 [build-dependencies]
@@ -27,6 +27,5 @@ cfg_aliases.workspace = true
 [dependencies]
 flume = { version = "0.11", default-features = false }
 protoflow-core.workspace = true
-tracing = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/lib/protoflow-syntax/Cargo.toml
+++ b/lib/protoflow-syntax/Cargo.toml
@@ -22,7 +22,6 @@ std = [
     "protoflow-core/std",
     "sysml-model?/std",
     "sysml-parser?/std",
-    "tracing?/std",
 ]
 sysml = [
     "protoflow-blocks/sysml",
@@ -34,7 +33,6 @@ tracing = [
     "protoflow-blocks/tracing",
     "protoflow-core/tracing",
     "sysml-parser?/tracing",
-    "dep:tracing",
 ]
 unstable = ["protoflow-blocks/unstable", "protoflow-core/unstable"]
 
@@ -54,6 +52,5 @@ sysml-model = { version = "=0.2.3", default-features = false, optional = true }
 sysml-parser = { version = "=0.2.3", default-features = false, features = [
     "error-stack",
 ], optional = true }
-tracing = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/lib/protoflow-zeromq/Cargo.toml
+++ b/lib/protoflow-zeromq/Cargo.toml
@@ -17,8 +17,8 @@ publish.workspace = true
 [features]
 default = ["all", "std"]
 all = ["tracing"]
-std = ["protoflow-core/std", "tracing?/std"] #, "zeromq/default"]
-tracing = ["protoflow-core/tracing", "dep:tracing"]
+std = ["protoflow-core/std"]           #, "zeromq/default"]
+tracing = ["protoflow-core/tracing"]
 unstable = ["protoflow-core/unstable"]
 
 [build-dependencies]
@@ -26,7 +26,6 @@ cfg_aliases.workspace = true
 
 [dependencies]
 protoflow-core.workspace = true
-tracing = { version = "0.1", default-features = false, optional = true }
 #zeromq = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/lib/protoflow/Cargo.toml
+++ b/lib/protoflow/Cargo.toml
@@ -36,7 +36,6 @@ std = [
     "protoflow-flume?/std",
     "protoflow-syntax?/std",
     "protoflow-zeromq?/std",
-    "tracing?/std",
 ]
 syntax = ["dep:protoflow-syntax"]
 sysml = [
@@ -46,7 +45,11 @@ sysml = [
     "protoflow-syntax?/sysml",
 ]
 tokio = ["protoflow-core/tokio"]
-tracing = ["dep:tracing", "clientele?/tracing"] # FIXME
+tracing = [
+    "protoflow-core/tracing",
+    "protoflow-blocks/tracing",
+    "clientele?/tracing",
+] # FIXME
 unstable = [
     "protoflow-blocks?/unstable",
     "protoflow-core/unstable",
@@ -79,7 +82,6 @@ protoflow-derive = { version = "=0.4.3", optional = true }
 protoflow-flume = { version = "=0.4.3", default-features = false, optional = true }
 protoflow-syntax = { version = "=0.4.3", default-features = false, optional = true }
 protoflow-zeromq = { version = "=0.4.3", default-features = false, optional = true }
-tracing = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.40.0", default-features = false }


### PR DESCRIPTION
Since `tracing` is now exported by `protoflow-core` for all the packages in workspace, it might make sense to get rid of unnecessary `tracing` dependencies for other packages.